### PR TITLE
Fix capture with multiple displays.

### DIFF
--- a/Sources/DSFColorSampler/DSFColorSampler.swift
+++ b/Sources/DSFColorSampler/DSFColorSampler.swift
@@ -248,23 +248,20 @@ private class DSFColorSamplerWindow: NSWindow {
 
 	override open func mouseMoved(with event: NSEvent) {
 		let point = NSEvent.mouseLocation
-
-		var count: UInt32 = 0
-		var displayID: CGDirectDisplayID = 0
-
-		if CGGetDisplaysWithPoint(point, 1, &displayID, &count) != CGError.success {
-			return
-		}
-
 		let captureSize: CGFloat = self.frame.size.width / self.pixelZoom
-		let screenFrame: NSRect = CGDisplayBounds(displayID)
-		let x: CGFloat = floor(point.x) - floor(captureSize / 2)
-		let y: CGFloat = screenFrame.size.height - floor(point.y) - floor(captureSize / 2)
-
+		let screenWithMouse = NSScreen.screens.first { NSMouseInRect(point, $0.frame, false) } // screen where mouse resides
+		let screenWithOrigin = NSScreen.screens.first { $0.frame.origin.x == 0 } // screen where menu bar resides, can be changed in System Settings->Displays->Arrange...
+		let isInOrigin = screenWithMouse == screenWithOrigin
+		let x = floor(point.x)
+		let y = isInOrigin ? screenWithMouse!.frame.height - floor(point.y) : screenWithOrigin!.frame.size.height  - floor(point.y)
+		let captureRect = NSRect(x: x - floor(captureSize / 2),
+								 y: y - floor(captureSize / 2),
+		                         width: captureSize,
+		                         height: captureSize)
 		let windowID = CGWindowID(self.windowNumber)
 
 		guard let image = CGWindowListCreateImage(
-			CGRect(x: x, y: y, width: captureSize, height: captureSize),
+			captureRect,
 			.optionOnScreenBelowWindow,
 			windowID,
 			.nominalResolution


### PR DESCRIPTION
Fix capture with multiple displays.

The image shows the error: capture content does not sync with mouse location when I use two displays.

![error](https://github.com/dagronf/DSFColorSampler/assets/55504/62a80378-bdf5-447f-ada1-1865a45c36c9)

BTW, The original Objective-C version (https://github.com/wentingliu/ScreenPicker) has the same issue.

After changing some coordinates calculation.

Two displays cases are tested.

![a1](https://github.com/dagronf/DSFColorSampler/assets/55504/5409a244-b996-4d63-9c98-39cc6a97b524)
![a4](https://github.com/dagronf/DSFColorSampler/assets/55504/c7c8c0e1-9dc9-4468-8870-6d579949c69a)
![a2](https://github.com/dagronf/DSFColorSampler/assets/55504/acd00b1e-7bb1-4776-9fce-eb9d1709d61f)
![a3](https://github.com/dagronf/DSFColorSampler/assets/55504/bdbc0aa0-d135-41f0-abc3-0eee36f9a8b4)

Three displays cases are tested.
![b1](https://github.com/dagronf/DSFColorSampler/assets/55504/4e3894d7-3142-48f0-bb3a-86175bbd9cde)
![b2](https://github.com/dagronf/DSFColorSampler/assets/55504/53c1bcec-91b3-4c69-9dc5-266f688fc8cd)
![b3](https://github.com/dagronf/DSFColorSampler/assets/55504/47a19271-7fa0-45c6-8038-f09514adddc2)
![b4](https://github.com/dagronf/DSFColorSampler/assets/55504/93652084-8580-4d1a-a50f-b62aabfbafc3)





