### PR TITLE
Prepare image for window's contentView in advance.

### DIFF
--- a/Sources/DSFColorSampler/DSFColorSampler.swift
+++ b/Sources/DSFColorSampler/DSFColorSampler.swift
@@ -170,6 +170,9 @@ private extension DSFColorSampler {
 		NSApplication.shared.activate(ignoringOtherApps: true)
 		self.screenPickerWindow!.makeKeyAndOrderFront(self)
 		self.screenPickerWindow!.orderedIndex = 0
+		
+		// prepare image for window's contentView in advance
+		self.screenPickerWindow!.mouseMoved(with: NSEvent())
 		NSCursor.hide()
 	}
 


### PR DESCRIPTION
Prepare image for window's contentView in advance to fix this issue.

|  Old | New |
| ------------- | ------------- |
| Click button, sampler window **DOES NOT** show at once. | Click button, sampler window shows at once. |
| ![old](https://github.com/dagronf/DSFColorSampler/assets/55504/a21b69d5-a3f2-4ea8-984f-1ba399537925)  | ![new](https://github.com/dagronf/DSFColorSampler/assets/55504/dfce41c1-0f1b-408c-88be-fd4b476dda6e)  |

