### PR TITLE
Make aperture look like surround one pixel.

### DIFF
--- a/Demo/ColorPickerTestApp/Base.lproj/MainMenu.xib
+++ b/Demo/ColorPickerTestApp/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21219" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21219"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -681,25 +681,25 @@
                     </menu>
                 </menuItem>
             </items>
-            <point key="canvasLocation" x="125" y="201"/>
+            <point key="canvasLocation" x="31" y="-278"/>
         </menu>
         <window title="ColorPickerTestApp" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="335" y="390" width="313" height="133"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
+            <rect key="contentRect" x="335" y="390" width="577" height="365"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1127"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="0.0" width="389" height="133"/>
-                <autoresizingMask key="autoresizingMask"/>
+                <rect key="frame" x="0.0" y="0.0" width="577" height="365"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="30" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EL5-rt-E4v">
-                        <rect key="frame" x="20" y="25" width="277" height="88"/>
+                        <rect key="frame" x="20" y="25" width="465" height="320"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GOi-FF-ova">
-                                <rect key="frame" x="0.0" y="20" width="86" height="48"/>
+                                <rect key="frame" x="0.0" y="136" width="149" height="48"/>
                                 <subviews>
                                     <button horizontalHuggingPriority="10" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Z77-Fi-3wA">
-                                        <rect key="frame" x="-7" y="21" width="100" height="32"/>
+                                        <rect key="frame" x="-7" y="21" width="163" height="32"/>
                                         <buttonCell key="cell" type="push" title="Pick" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="dnI-5H-L7Z">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -729,10 +729,10 @@
                                 </customSpacing>
                             </stackView>
                             <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8nt-lf-pnl">
-                                <rect key="frame" x="116" y="3" width="63" height="83"/>
+                                <rect key="frame" x="179" y="86" width="128" height="148"/>
                                 <subviews>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CME-pR-pid">
-                                        <rect key="frame" x="14" y="67" width="35" height="16"/>
+                                        <rect key="frame" x="47" y="132" width="35" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="color" id="y4x-rE-5dF">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -740,10 +740,10 @@
                                         </textFieldCell>
                                     </textField>
                                     <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="j1T-Wo-Me3">
-                                        <rect key="frame" x="0.0" y="0.0" width="63" height="63"/>
+                                        <rect key="frame" x="-3" y="-2" width="134" height="132"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="63" id="IGy-WL-uME"/>
-                                            <constraint firstAttribute="width" constant="63" id="gQE-1j-aO5"/>
+                                            <constraint firstAttribute="height" constant="128" id="IGy-WL-uME"/>
+                                            <constraint firstAttribute="width" constant="128" id="gQE-1j-aO5"/>
                                         </constraints>
                                         <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                     </colorWell>
@@ -758,10 +758,10 @@
                                 </customSpacing>
                             </stackView>
                             <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fnx-WC-0PZ">
-                                <rect key="frame" x="209" y="4" width="68" height="81"/>
+                                <rect key="frame" x="337" y="85" width="128" height="151"/>
                                 <subviews>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W4L-1n-B3x">
-                                        <rect key="frame" x="-2" y="65" width="72" height="16"/>
+                                        <rect key="frame" x="28" y="135" width="72" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="screenshot" id="7SA-Mv-TIn">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -769,10 +769,10 @@
                                         </textFieldCell>
                                     </textField>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KUk-If-IdF" customClass="CustomImageView" customModule="ColorPickerTestApp" customModuleProvider="target">
-                                        <rect key="frame" x="3" y="-3" width="63" height="64"/>
+                                        <rect key="frame" x="-3" y="-3" width="134" height="134"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="57" id="SMq-ke-xB8"/>
-                                            <constraint firstAttribute="height" constant="58" id="fPX-Yo-5ZA"/>
+                                            <constraint firstAttribute="width" constant="128" id="SMq-ke-xB8"/>
+                                            <constraint firstAttribute="height" constant="128" id="fPX-Yo-5ZA"/>
                                         </constraints>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" imageFrameStyle="grayBezel" id="Ax5-sL-Lie"/>
                                     </imageView>
@@ -806,7 +806,7 @@
                     <constraint firstAttribute="bottom" secondItem="EL5-rt-E4v" secondAttribute="bottom" constant="25" id="pHq-cj-ucG"/>
                 </constraints>
             </view>
-            <point key="canvasLocation" x="12.5" y="-44.5"/>
+            <point key="canvasLocation" x="43.5" y="39.5"/>
         </window>
     </objects>
 </document>

--- a/Sources/DSFColorSampler/DSFColorSampler.swift
+++ b/Sources/DSFColorSampler/DSFColorSampler.swift
@@ -63,6 +63,9 @@ import Cocoa
 	/// Color and location selection block callback. If the user cancels the selection (pressed ESC) then selectedColor will be nil
 	public typealias LocationChangedBlock = (_ currentImage: NSImage, NSColor) -> Void
 
+	fileprivate static let pixelMaxZoom: CGFloat = 7
+	fileprivate static let pixelMinZoom: CGFloat = 1
+	
 	/// Display the color selector and allow the user to select a color
 	///
 	/// - Parameters:
@@ -145,8 +148,9 @@ private extension DSFColorSampler {
 	}
 
 	func run() {
+		let size = pow(2, DSFColorSampler.pixelMaxZoom)
 		self.screenPickerWindow = DSFColorSamplerWindow(
-			contentRect: NSRect(x: 0, y: 0, width: 125, height: 125),
+			contentRect: NSRect(x: 0, y: 0, width: size, height: size),
 			styleMask: .borderless,
 			backing: .buffered,
 			defer: true
@@ -220,7 +224,7 @@ private protocol DSFColorSamplerDelegate: NSWindowDelegate {
 }
 
 private class DSFColorSamplerWindow: NSWindow {
-	private var pixelZoom: CGFloat = 7
+	private var pixelZoom: CGFloat = 2
 
 	var _image: CGImage?
 
@@ -251,7 +255,7 @@ private class DSFColorSamplerWindow: NSWindow {
 
 	override open func mouseMoved(with event: NSEvent) {
 		let point = NSEvent.mouseLocation
-		let captureSize: CGFloat = self.frame.size.width / self.pixelZoom
+		let captureSize = self.frame.size.width / pow(2, self.pixelZoom - 1) + 1
 		guard
 			// screen where mouse resides
 			let screenWithMouse = NSScreen.screens.first(where: { NSMouseInRect(point, $0.frame, false) }),
@@ -325,7 +329,7 @@ private class DSFColorSamplerWindow: NSWindow {
 		else if event.deltaY < -0.01 {
 			self.pixelZoom -= 1
 		}
-		self.pixelZoom = self.pixelZoom.clamped(to: 2 ... 24)
+		self.pixelZoom = self.pixelZoom.clamped(to: DSFColorSampler.pixelMinZoom ... DSFColorSampler.pixelMaxZoom)
 
 		(self.contentView as? DSFColorSamplerView)?.pixelZoom = self.pixelZoom
 
@@ -348,7 +352,7 @@ private class DSFColorSamplerWindow: NSWindow {
 // MARK: - DSFColorSamplerView
 
 private class DSFColorSamplerView: NSView {
-	var pixelZoom: CGFloat = 7
+	var pixelZoom: CGFloat = 2
 	var _image: CGImage?
 
 	// Wrapper to work around lack of cgContext on 10.9
@@ -389,7 +393,7 @@ private class DSFColorSamplerView: NSView {
 		}
 
 		// draw the aperture
-		let apertureSize: CGFloat = self.pixelZoom
+		let apertureSize: CGFloat = width / (pow(2, DSFColorSampler.pixelMaxZoom - self.pixelZoom + 1) + 1)
 		let x: CGFloat = (width / 2.0) - (apertureSize / 2.0)
 		let y: CGFloat = (height / 2.0) - (apertureSize / 2.0)
 


### PR DESCRIPTION
Make aperture look like surround one pixel.

In the old version, the aperture sometimes contains more than one pixel, so, users may get confused,  which pixel the picking color comes from.

<img width="716" alt="problem which pixel" src="https://github.com/dagronf/DSFColorSampler/assets/55504/7fdcdfce-6d9b-45e5-ac66-0eb9c93a9356">

---

|  Old | New |
| ------------- | ------------- |
| Aperture sometimes contains more than one pixel | Aperture always contains only one pixel  |
| ![old](https://github.com/dagronf/DSFColorSampler/assets/55504/603202da-36eb-4640-b9fa-5ab90a472fdb)  |  ![new](https://github.com/dagronf/DSFColorSampler/assets/55504/156fd20e-4e4a-4f30-b37b-c08a94a54f1b) |



